### PR TITLE
tma_annotate_backend leaks annotation to front-end

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -89,7 +89,7 @@ function tma_annotate_css($mce_css) {
 
 // Don't display annotations in frontend
 function tma_annotate_backend($content) {
-    return preg_replace('/(<[^>]+) class="annotation" style=".*?"/i', '$1', $content);
+    return preg_replace('/(<[^>]+) class="annotation".*?data-annotation=".*?"/i', '$1', $content);
 }
 
 function tma_annotate() {


### PR DESCRIPTION
Line 92 strips out the style element of the tag, but leaves the data attributes behind. This means the annotation data is visible when the post is published, for clever users who view source.